### PR TITLE
add pypi optional deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,11 @@ dev = [
   "pylint",
   "ruff",
 ]
+pypi = [
+  "build",
+  "setuptools_scm[toml]",
+  "wheel",
+]
 
 [tool.setuptools]
 package-dir = { "" = "napari-afmreader/src" }


### PR DESCRIPTION
# TopoStats Pull Requests

Adds `.[pypi]` optional dependencies so the test-pypi publishing workflow can work.

---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Documentation has been updated and builds.
- [x] Pre-commit checks pass.
- [x] New functions/methods have typehints and docstrings.
- [x] New functions/methods have tests which check the intended behaviour is correct.
