### PR TITLE
Drop the never-necessary `wheel` from build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
   "setuptools>=45",
-  "wheel",
   "setuptools_scm[toml]>=6.2"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I fixed this in `setuptools`' docs long ago.