### PR TITLE
Add DOI to CITATION.cff and badge to README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,6 +33,8 @@ identifiers:
   - type: url
     value: 'https://github.com/AFM-SPM/napari-AFMReader.git'
     description: source code
+  - type: doi
+    value: 10.15131/shef.data.29263577
 abstract: >-
   napari-AFMReader is Napari plugin to read Atomic Force Microscopy images.
 keywords:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astr
 [![codecov](https://codecov.io/gh/AFM-SPM/napari-afmreader/branch/dev/graph/badge.svg)](https://codecov.io/gh/AFM-SPM/napari-afmreader)
 [![pre-commit.ci
 status](https://results.pre-commit.ci/badge/github/AFM-SPM/napari-afmreader/main.svg)](https://results.pre-commit.ci/latest/github/AFM-SPM/napari-afmreader/main)
+[![ORDA](https://img.shields.io/badge/ORDA--DOI-10.15131/shef.data.29263577.v.1-lightgrey)](https://figshare.shef.ac.uk/articles/software/napar-AFMReader/)
 [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow)](https://fair-software.eu)
 
 </div>


### PR DESCRIPTION
Having submitted to [ORDA](https://orda.shef.ac.uk) I've added the reserved DOI to the `CITATION.cff`.

I've also added a DOI badge but this _will_ need tweaking in the future once the submission has been reviewed, approved and published.