### PR TITLE
Adds required codecov token to test workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
-# TopoStats Pull Requests
+# Napari-AFMReader Pull Requests
 
 Please provide a descriptive summary of the changes your Pull Request introduces.
 
 The [Software Development](https://afm-spm.github.io/TopoStats/main/contributing.html#software-development) section of
-the Contributing Guidelines may be useful if you are unfamiliar with linting, pre-commit, docstrings and testing.
+the (TopoStats) Contributing Guidelines may be useful if you are unfamiliar with linting, pre-commit, docstrings and testing.
 
 **NB** - This header should be replaced with the description but please complete the below checklist or a short
 description of why a particular item is not relevant.

--- a/.github/workflows/main-codecov.yaml
+++ b/.github/workflows/main-codecov.yaml
@@ -1,0 +1,38 @@
+name: Generate Main CodeCov Report
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Generate Main CodeCov Report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Upgrade pip and install test dependencies
+        run: |
+          pip install --upgrade virtualenv
+          pip install --upgrade pip setuptools
+          pip show pip setuptools
+          virtualenv --upgrade-embed-wheels
+          # virtualenv --reset-app-data
+          pip install -e .[tests]
+      - name: Test with pytest
+        run: |
+          pytest --cov=napari-afmreader -x
+      - name: Determine coverage
+        run: |
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/main-codecov.yaml
+++ b/.github/workflows/main-codecov.yaml
@@ -35,4 +35,3 @@ jobs:
         uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,6 +51,8 @@ jobs:
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Setup tmate session
         if: ${{ failure() }}


### PR DESCRIPTION
I noticed that there was no code coverage given for the main branch. Upon reading [this](https://docs.codecov.com/docs/github-2-getting-a-codecov-account-and-uploading-coverage), I found that you now need to make a codecov acount and add the repository secrets to the test environment workflow.

Should be able to see it working now [here](https://app.codecov.io/gh/AFM-SPM/napari-AFMReader/tree/update-codecov-workflow).

Also saw this template needed updating so did that too :)

---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Documentation has been updated and builds.
- [x] Pre-commit checks pass.
- [x] New functions/methods have typehints and docstrings.
- [x] New functions/methods have tests which check the intended behaviour is correct.
